### PR TITLE
fix: guard Core.cs Migrate() with IHistoryRepository (Galera-safe)

### DIFF
--- a/ServiceTimePlanningPlugin/Core.cs
+++ b/ServiceTimePlanningPlugin/Core.cs
@@ -16,6 +16,8 @@ using Infrastructure.Helpers;
 using Installers;
 using Messages;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microting.eForm.Dto;
 using Microting.TimePlanningBase.Infrastructure.Data;
 using Microting.TimePlanningBase.Infrastructure.Data.Factories;
@@ -144,7 +146,11 @@ public class Core : ISdkEventHandler
                 TimePlanningPnContextFactory contextFactory = new TimePlanningPnContextFactory();
 
                 _dbContext = contextFactory.CreateDbContext(new[] { connectionString });
-                _dbContext.Database.Migrate();
+                var historyRepo = _dbContext.GetService<IHistoryRepository>();
+                if (!historyRepo.Exists() || _dbContext.Database.GetPendingMigrations().Any())
+                {
+                    _dbContext.Database.Migrate();
+                }
 
                 _dbContextHelper = new DbContextHelper(connectionString);
 


### PR DESCRIPTION
Guard Database.Migrate() with IHistoryRepository.Exists() — no DDL when schema is current, falls back to Migrate() on fresh install or pending migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)